### PR TITLE
Allow users to scope global searches for popular types of queries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem 'kaminari', github: 'jcoyne/kaminari', branch: 'sufia'
 # branch
 gem 'hydra-derivatives', github: 'projecthydra/hydra-derivatives', ref: 'cc031e7'
 gem 'active-fedora', '~> 9'
+gem 'blacklight_range_limit'
 
 # Once Sufia's references are updated use v2.0 instead
 #gem 'hydra-derivatives', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,10 @@ GEM
     blacklight_advanced_search (5.2.1)
       blacklight (~> 5.15)
       parslet
+    blacklight_range_limit (5.2.0)
+      blacklight (~> 5.15)
+      jquery-rails
+      rails (>= 3.0, < 5.0)
     blankslate (3.1.3)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
@@ -703,6 +707,7 @@ PLATFORMS
 DEPENDENCIES
   active-fedora (~> 9)
   any_login
+  blacklight_range_limit
   capistrano (~> 3.4.0)
   capistrano-bundler
   capistrano-passenger (~> 0.2)

--- a/app/assets/stylesheets/cma_archives.scss
+++ b/app/assets/stylesheets/cma_archives.scss
@@ -1,3 +1,5 @@
+@import 'bootstrap_overrides';
+
 .lightbox {
   display: -ms-flex;
   display: flex;
@@ -93,3 +95,17 @@
   border-radius: 0;
 }
 
+/**
+ * Custom styling to make global search look more like base Blacklight
+ * Can be deleted if code is brought closer to source
+ */
+.for-search-field {
+  background: $cma-gray;
+  border-radius: 4px 0 0 4px;
+}
+
+.for-search-field select {
+  background: transparent;
+  border: none;
+  width: 20ch;
+}

--- a/app/jobs/batch_ingest_job.rb
+++ b/app/jobs/batch_ingest_job.rb
@@ -113,10 +113,10 @@ class BatchIngestJob < ActiveFedoraIdBasedJob
 
 	def create_collection(title, creator)
 		Rails.logger.info "[#{log_prefix}] Creating a new collection - #{title}"
-		collection = Collection.new(title: title)
-		collection.depositor = creator
-        collection.edit_users = [creator]
-		collection.save
+		collection = Collection.create(title: title,
+          depositor: creator,
+          edit_users: [creator],
+          resource_type: ["Collection"])
 
 		collection
 	end

--- a/app/jobs/extract_exif_metadata_job.rb
+++ b/app/jobs/extract_exif_metadata_job.rb
@@ -50,6 +50,11 @@ class ExtractExifMetadataJob < ActiveFedoraIdBasedJob
     generic_file[:language] += ["en"]
     generic_file[:language].uniq!		
 
+    # TODO: Actually set this dynamically based on MIME type instead of
+    #       being hard coded
+    generic_file[:resource_type] += ["Image"]
+    generic_file[:resource_type].uniq!
+
     generic_file
   end
     

--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -19,22 +19,11 @@ class ImportUrlJob < ActiveFedoraIdBasedJob
       "file_size" => 0,
     }
     
-    # Infer the MIME type from the file name since it was not
-    # provided by any HTTP headers
-
-    # Because of a bug with DNG files we need to coax MiniMagick into
-    # loading the right library. Until a better solution comes along
-    # the way to do this is by forcing an extension onto the file but
-    # only for DNGs
-    #
-    # This is not perfect but it will work with 99% of the cases that
-    # are present
     Rails.logger.info "[IMPORT URL] Preparing #{generic_file.import_url} for processing"
     mime_types = MIME::Types.of(uri.basename)
     generic_file.mime_type = mime_types.empty? ? "application/octet-stream" : mime_types.first.content_type
     tmp_file = [id] 
     tmp_file << ".#{mime_types.first.extensions.first}" unless mime_types.blank?   
-
     # Can't use TempfileService here because we are trying to
     # ingest the content into Fedora and that method assumes
     # that it is already there

--- a/app/services/cma/collection_indexing_service.rb
+++ b/app/services/cma/collection_indexing_service.rb
@@ -2,7 +2,7 @@ module CMA
   class CollectionIndexingService < ActiveFedora::IndexingService
     def generate_solr_document
       super.tap do |solr_doc|
-        solr_doc[Solrizer.solr_name("date_created", :stored_sortable)] = object.date_created.first unless object.date_created.blank?
+        solr_doc[Solrizer.solr_name("date_created", :stored_sortable, type: :date)] = object.date_created.first unless object.date_created.blank?
         solr_doc[Solrizer.solr_name("primary_title", :stored_sortable)] = object.title unless object.title.blank?
       end
     end

--- a/app/services/cma/generic_file_indexing_service.rb
+++ b/app/services/cma/generic_file_indexing_service.rb
@@ -14,15 +14,16 @@ module CMA
         # between files on disk (in fcrepo.binary-store-path) and objects
         # in the repository.
         solr_doc[Solrizer.solr_name('digest', :symbol)] = digest_from_content
+        solr_doc[Solrizer.solr_name('photographer')] = object.photographer
+        solr_doc[Solrizer.solr_name('accession_number', :stored_searchable)] = object.accession_number
+
         # Put the thumbnail and access copies into Solr for faster retrieval if they are
         # present
         solr_doc["thumbnail_uri_ssm"] = object.thumbnail.uri.to_s
         solr_doc["preview_uri_ssm"] = object.access.uri.to_s
         # Sorting fields cannot be multivalued
         solr_doc[Solrizer.solr_name("primary_title", :stored_sortable)] = object.title.first unless object.title.empty?
-        # TODO: Figure out how to reliably cast to a date for better
-        #       sorting
-        solr_doc[Solrizer.solr_name("date_created", :stored_sortable)] = object.date_created.first unless object.date_created.blank?
+        solr_doc[Solrizer.solr_name("date_created", :stored_sortable, type: :date)] = object.date_created.first unless object.date_created.blank?
 
         object.index_collection_ids(solr_doc) unless Sufia.config.collection_facet.nil?
       end

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -4,8 +4,16 @@
     <div class="row">
       <div class="col-xs-12">
         <div class="input-group">
+          <span class="input-group-addon for-search-field">
+            <label for="search_field" class="sr-only">Search field(s)</label>
+            <%= select_tag(:search_field,
+                options_for_select(search_fields, h(params[:search_field])),
+                title: "Limit search to",
+                id: "search_field",
+                class: "search_field") %>
+          </span>
 
-          <label class="sr-only" for="search-field-header"><%= t("sufia.search.form.q.label") %></label>
+          <label class="sr-only" for="q"><%= t("sufia.search.form.q.label") %></label>
           <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("sufia.search.form.q.placeholder") %>
 
           <div class="input-group-btn">

--- a/app/views/generic_files/show.html.erb
+++ b/app/views/generic_files/show.html.erb
@@ -1,5 +1,3 @@
-<%= console %>
-
 <%= render_breadcrumbs builder: Sufia::BootstrapBreadcrumbsBuilder %>
 <div class="container-fluid">
 <div class="row">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   config.log_tags = [ :uuid ]
-  config.log_level = :info
+  config.log_level = :debug
   config.logger = Logger.new(Rails.root.join("log", Rails.env + ".log"))
 
   # Reroute STDERR to a log file in the same directory for easier

--- a/spec/jobs/batch_ingest_job_spec.rb
+++ b/spec/jobs/batch_ingest_job_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe BatchIngestJob do
       expect(coll.date_created).to contain_exactly "2016-03"
       expect(coll.collections).to contain_exactly @parent
       expect(coll.members.count).to be 3
+      expect(coll.resource_type).to contain_exactly "Collection"
     end
 
     it "does not reprocess existing content" do

--- a/spec/jobs/extract_exif_metadata_spec.rb
+++ b/spec/jobs/extract_exif_metadata_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe ExtractExifMetadataJob do
       expect(gf.rights).to eq ["Copyright, The Cleveland Museum of Art"]
       expect(gf.contributor).to eq ["Cleveland Museum of Art"]
       expect(gf.language).to eq ["en"]
+      expect(gf.resource_type).to contain_exactly "Image"
     end
  end
 


### PR DESCRIPTION
Implement somewhat robust global search functionality so that people can search by 

- Accession number
- Contributor
- Identifier
- Subjects