### PR TITLE
Allow for large file sizes in indexed field

### DIFF
--- a/app/models/concerns/cma/collection/collection_size.rb
+++ b/app/models/concerns/cma/collection/collection_size.rb
@@ -65,7 +65,7 @@ module CMA
         end
  
         def file_size_field
-          "file_size_isi"
+          @file_size_field ||= Solrizer.solr_name("file_size", :stored_sortable, type: :long)
         end
     end
   end  

--- a/app/services/cma/generic_file_indexing_service.rb
+++ b/app/services/cma/generic_file_indexing_service.rb
@@ -1,14 +1,12 @@
 module CMA
   class GenericFileIndexingService < ActiveFedora::IndexingService
-    STORED_INDEXED_INTEGER = Solrizer::Descriptor.new(:integer, :stored, :indexed)
-
     def generate_solr_document
       super.tap do |solr_doc|
         solr_doc[Solrizer.solr_name('label')] = object.label
         solr_doc[Solrizer.solr_name('file_format')] = object.file_format
         solr_doc[Solrizer.solr_name('file_format', :facetable)] = object.file_format
         # Enable if full text indexing is ever required
-        solr_doc[Solrizer.solr_name('file_size', STORED_INDEXED_INTEGER)] = object.content.size.to_i
+        solr_doc[Solrizer.solr_name('file_size', :stored_sortable, type: :long)] = object.content.size.to_i
         solr_doc[Solrizer.solr_name('mime_type', :symbol)] = object.mime_type
         # Index the Fedora-generated SHA1 digest to create a linkage
         # between files on disk (in fcrepo.binary-store-path) and objects

--- a/spec/services/generic_file_indexing_service_spec.rb
+++ b/spec/services/generic_file_indexing_service_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe CMA::GenericFileIndexingService do
+  describe "#generate_solr_document" do
+    before(:each) do
+      allow(gf.content).to receive(:has_content?).and_return(false)
+    end
+
+    let(:gf) do
+      GenericFile.new(title: ["RSpec (GenericFileIndexingService)"],
+        mime_type: "image/tiff",
+        contributor: ["Contributor"],
+        photographer: ["Photographer"],
+        accession_number: ["1942.214.10"])
+    end  
+ 
+    let(:small_file) { 415 }
+    let(:large_file) { 5402680725 }
+
+    it "collapses contributors into one facet" do
+      solr_doc = gf.to_solr
+      expect(solr_doc["contributor_facet_sim"]).to contain_exactly "Contributor", "Photographer"
+    end
+
+    it "indexes multiple variations for accession numbers" do
+      solr_doc = gf.to_solr
+      expect(solr_doc["accession_number_tesim"]).to contain_exactly "1942.214", "1942.214.10"
+    end
+  
+    it "indexes small files" do
+      
+      allow(gf.content).to receive(:size).and_return(small_file)
+      solr_doc = gf.to_solr
+      expect(solr_doc["file_size_ltsi"]).to eq 415
+    end
+
+    it "indexes large files" do
+      allow(gf.content).to receive(:size).and_return(large_file)
+      solr_doc = gf.to_solr
+      expect(solr_doc["file_size_ltsi"]).to eq 5402680725
+    end
+  end 
+end


### PR DESCRIPTION
Indexed file sizes in the Solr index need to be greater than 32 bits to handle file sizes larger than 2GB. This fix rolls up a patch which can be resolved by reindexing everything.