### PR TITLE
Persist filters when changing views

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -212,12 +212,11 @@ class CatalogController < ApplicationController
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
     # label is key, solr field is value
-    config.add_sort_field "date_created_ssi ASC", label: "Date Created \u25bc"
-    config.add_sort_field "date_created_ssi DESC", label: "Date Created \u25b2"
-    config.add_sort_field "primary_title_ssi ASC", label: "Title \u25bc", 
-      default: true
-    config.add_sort_field "primary_title_ssi DESC", label: "Title \u25b2"
-    config.add_sort_field "score DESC, #{uploaded_field} DESC \u25b2", label: "Relevance"
+    config.add_sort_field "date_created_ssi ASC", label: "Date Created <i class=\"fa fa-chevron-down\"></i>"
+    config.add_sort_field "date_created_ssi DESC", label: "Date Created <i class=\"fa fa-chevron-up\"></i>"
+    config.add_sort_field "primary_title_ssi ASC", label: "Title <i class=\"fa fa-chevron-down\"></i>", default: true
+    config.add_sort_field "primary_title_ssi DESC", label: "Title <i class=\"fa fa-chevron-up\"></i>"
+    config.add_sort_field "score DESC, #{uploaded_field} DESC <i class=\"fa fa-chevron-down\"></i>", label: "Relevance"
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/views/catalog/_per_page_widget.html.erb
+++ b/app/views/catalog/_per_page_widget.html.erb
@@ -6,7 +6,7 @@
   </button>
   <ul class="dropdown-menu" role="menu">
     <%- per_page_options_for_select.each do |(label, count)| %>
-      <li><%= link_to(label, url_for(params_for_search(:per_page => count))) %></li>
+      <li><%= link_to label, url_for(params_for_search(per_page: count)) %></li>
     <%- end -%>
   </ul>
 <% end %>

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -1,12 +1,12 @@
 <% if show_sort_and_per_page? and !active_sort_fields.blank? %>
 <div id="sort-dropdown" class="btn-group">
   <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-      <%= t('blacklight.search.sort.label', :field =>current_sort_field.label) %> 
+      <%= raw t('blacklight.search.sort.label', field: current_sort_field.label) %> 
   </button>
 
   <ul class="dropdown-menu" role="menu">
       <%- active_sort_fields.each do |sort_key, field_config| %>
-        <li><%= link_to(field_config.label, url_for(params_for_search(:sort => sort_key))) %></li>
+        <li><%= link_to raw(field_config.label), url_for(params_for_search(sort: sort_key)) %></li>
       <%- end -%>
   </ul>
 </div>

--- a/app/views/collections/_per_page_widget.html.erb
+++ b/app/views/collections/_per_page_widget.html.erb
@@ -1,8 +1,10 @@
+<%= console %>
+
         <div id="per_page-dropdown" class="btn-group">
           <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><%= current_per_page %> per page <i class="fa fa-chevron-down"></i></button>
           <ul class="dropdown-menu">
             <% per_page_options_for_select.each do |(label, value)| %>
-              <li><%= link_to "#{value} per page", collections.collection_path(@collection, per_page: value) %></li>
+              <li><%= link_to "#{value} per page", collections.collection_path(@collection, params_for_search(per_page: value)) %></li>
             <% end %>
           </ul>
         </div>

--- a/app/views/collections/_sort_widget.html.erb
+++ b/app/views/collections/_sort_widget.html.erb
@@ -1,8 +1,10 @@
         <div id="sort-dropdown" class="btn-group">
-          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><%= current_sort_field.label %></button>
+          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><%= raw(current_sort_field.label) %></button>
           <ul class="dropdown-menu">
             <% active_sort_fields.each do |key, sort_order| %>
-              <li><%= link_to sort_order.label, collections.collection_path(@collection, per_page: current_per_page, sort: key) %></li>
+              <li>
+                <%= link_to raw(sort_order.label), collections.collection_path(@collection, params_for_search(sort: key)) %>
+              </li>
             <% end %>
           </ul>
         </div>

--- a/app/views/collections/_view_type_group.html.erb
+++ b/app/views/collections/_view_type_group.html.erb
@@ -3,7 +3,7 @@
   <span class="sr-only"><%= t('blacklight.search.view_title') %></span>
   <div class="view-type-group btn-group pull-right">
     <%  document_index_views.each do |view, config| %>
-      <%= link_to collections.collection_path(params[:id], view: view), title: t("blacklight.search.view_title.#{view}", default: t("blacklight.search.view.#{view}", default: blacklight_config.view[view].title)), class: "btn btn-default view-type-#{ view.to_s.parameterize } #{"active" if document_index_view_type == view}" do %>
+      <%= link_to collections.collection_path(params[:id], params_for_search(view: view)), title: t("blacklight.search.view_title.#{view}", default: t("blacklight.search.view.#{view}", default: blacklight_config.view[view].title)), class: "btn btn-default view-type-#{ view.to_s.parameterize } #{"active" if document_index_view_type == view}" do %>
         <%= render_view_type_group_icon view %>
         <span class="caption"><%= t("blacklight.search.view.#{view}") %></span>
       <% end %>


### PR DESCRIPTION
1. Make both facets use the same caret dropdown to clean up the interface
2. Make sure that facets are not forgotten when you change Per Page, Sort Order, or switch between gallery view and list view

https://github.com/ClevelandArtGIT/cma-archives/issues/29
