### PR TITLE
Write minter-state to a safer location

### DIFF
--- a/config/initializers/mailboxer.rb
+++ b/config/initializers/mailboxer.rb
@@ -1,10 +1,10 @@
 Mailboxer.setup do |config|
 
   #Configures if you application uses or not email sending for Notifications and Messages
-  config.uses_emails = true
+  config.uses_emails = false
 
   #Configures the default from for emails sent for Messages and Notifications
-  config.default_from = "no-reply@mailboxer.com"
+  config.default_from = "cmarepository@clevelandart.org"
 
   #Configures the methods needed by mailboxer
   config.email_method = :mailboxer_email

--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -91,7 +91,7 @@ Sufia.config do |config|
   # Sufia uses NOIDs for files and collections instead of Fedora UUIDs
   # where NOID = 10-character string and UUID = 32-character string w/ hyphens
   config.enable_noids = true
-
+  config.minter_statefile = "log/minter-state.#{Rails.env}"
   # Specify a different template for your repository's NOID IDs
   # config.noid_template = ".reeddeeddk"
 


### PR DESCRIPTION
Keep minter-state underneath of the application rather than /tmp so that it reduces the risk of being overwritten by other processes