### PR TITLE
Hide nil dates in the gallery view

### DIFF
--- a/app/views/catalog/_gallery_details_generic_file.html.erb
+++ b/app/views/catalog/_gallery_details_generic_file.html.erb
@@ -1,1 +1,2 @@
-<span>(<%= document.date_created %>)</span>
+<div><%= document.date_created unless document.date_created.nil? %></div>
+


### PR DESCRIPTION
If dates are not set than do not display an empty set of parens. This design may need to be revisited with a future overhaul.