### PR TITLE
Ensure that collection permissions inherit from parents

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,7 +1,7 @@
 set :rails_env, :staging
 set :branch, :master
 set :deploy_to, "/var/www/sites/archives/rails/cma-archives/"
-set :log_level, :debug
+set :log_level, :info
 
 # server-based syntax
 # ======================

--- a/spec/jobs/batch_ingest_job_spec.rb
+++ b/spec/jobs/batch_ingest_job_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe BatchIngestJob do
   before(:all) do
     @parent = Collection.new(title: "Batch Tests", id: "umbrella-coll")
     @parent.edit_users = ["admin"]
+    @parent.edit_groups = ["rspec"]
     @parent.depositor = "admin"
     @parent.save
  end
@@ -39,6 +40,7 @@ RSpec.describe BatchIngestJob do
       expect(coll.collections).to contain_exactly @parent
       expect(coll.members.count).to be 3
       expect(coll.resource_type).to contain_exactly "Collection"
+      expect(coll.edit_groups).to contain_exactly "admin", "rspec"
     end
 
     it "does not reprocess existing content" do


### PR DESCRIPTION
A bug prevented collection permissions from cascading properly so that they were effectively invisible in the interface. They could be fixed manually by hand but this patch ensures not only that the edit_groups cascade but that the groups are inclusive rather than overwritten.