### PR TITLE
Remove about, contact, and help links for now

### DIFF
--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -1,0 +1,14 @@
+<div id="masthead_controls" class="container-fluid">
+  <div class="row">
+    <div class="col-xs-12 col-sm-5 col-md-6">
+      <nav class="navbar navbar-default" role="navigation">
+        <ul class="nav navbar-nav">
+            <li <%= 'class=active' if current_page?(sufia.root_path) %>><a href="<%= sufia.root_path %>">Home</a></li>
+        </ul><!-- /.nav -->
+      </nav><!-- /.navbar -->
+    </div>
+    <div class="col-xs-12 col-sm-7 col-md-6">
+      <%= render partial: 'catalog/search_form' %>
+    </div>
+  </div> <!-- /.row -->
+</div><!-- /#masthead_controls -->


### PR DESCRIPTION
Since these are still defaults and the interface is meant for internal customers only suppress the about, help, and contact pages for the time being. 