### PR TITLE
Streamline the process of ingest by loading generic files 

### DIFF
--- a/app/actors/cma/generic_file/actor.rb
+++ b/app/actors/cma/generic_file/actor.rb
@@ -1,0 +1,7 @@
+module CMA::GenericFile
+  class Actor < Sufia::GenericFile::Actor
+    def push_characterize_job
+      Sufia.queue.push ProcessImportedFileJob.new(@generic_file.id)
+    end
+  end
+end

--- a/app/jobs/batch_ingest_job.rb
+++ b/app/jobs/batch_ingest_job.rb
@@ -3,9 +3,11 @@ require 'csv'
 class BatchIngestJob < ActiveFedoraIdBasedJob
 	attr_accessor :batch_file 
 
+    # :nocov:
 	def queue_name
 		:batch_ingest
 	end
+    # :nocov:
 
 	def initialize(csv_path, batch_id = nil)
 		self.batch_file = csv_path
@@ -101,7 +103,6 @@ class BatchIngestJob < ActiveFedoraIdBasedJob
           Rails.logger.info "[#{log_prefix}] Ingesting #{gf.id} (#{filename})"
           resources_to_import << gf.id
 	    else
-          # Defer checksumming to the BatchIngestJob
           gf_id = current_children_ids.first
           fixity = Fixity.new(gf_id)
           unless fixity.equal?

--- a/app/jobs/batch_manifest_job.rb
+++ b/app/jobs/batch_manifest_job.rb
@@ -5,9 +5,11 @@ class BatchManifestJob
 
   attr_reader :batch, :file
 
+  # :nocov:
   def queue_name
     :batch_manifest
   end
+  # :nocov:
 
   def initialize id
     @batch = Batch.find id if Batch.exists? id
@@ -38,7 +40,7 @@ class BatchManifestJob
     csv_file << [:file, :local_path, :fedora_uri, :local_checksum, :remote_checksum]
     @batch.generic_files.each do |gf|
       fixity = Fixity.new gf.id
-      csv_file << [gf.label, gf.import_url, gf.uri, fixity.local[:checksum], fixity.remote[:checksum]]
+      csv_file << [gf.label, gf.import_url, gf.uri, fixity.local, fixity.remote]
     end
   end
 end

--- a/app/jobs/batch_update_job.rb
+++ b/app/jobs/batch_update_job.rb
@@ -3,9 +3,11 @@ require 'csv'
 class BatchUpdateJob < ActiveFedoraIdBasedJob
 	attr_accessor :batch_file 
 
+    # :nocov:
 	def queue_name
 		:batch_update
 	end
+    # :nocov:
 
 	def initialize(csv_path)
 		self.batch_file = csv_path

--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -6,9 +6,11 @@
 # It might be wise to only encode if the URL is file:///
 # based.
 class ImportUrlJob < ActiveFedoraIdBasedJob
+  # :nocov:
   def queue_name
     :import
   end
+  # :nocov:
 
   def run
     user = User.find_by_user_key(generic_file.depositor) || User.first
@@ -38,7 +40,7 @@ class ImportUrlJob < ActiveFedoraIdBasedJob
       # Don't pass a message through Mailboxer any more; if the status
       # fails it can be handled differently in a future refactor of the
       # jobs workflow
-      Sufia::GenericFile::Actor.new(generic_file, user).create_content(f, uri.basename, 'content', generic_file.mime_type)
+      CMA::GenericFile::Actor.new(generic_file, user).create_content(f, uri.basename, 'content', generic_file.mime_type)
     end
   end
 end

--- a/app/jobs/install_featured_collections_job.rb
+++ b/app/jobs/install_featured_collections_job.rb
@@ -5,9 +5,11 @@ class InstallFeaturedCollectionsJob
     self.collections = collections
   end
 
+  # :nocov:
   def queue_name
     :collections
   end
+  # :nocov:
 
   def run
     featured_collections = collections.is_a?(String) ?

--- a/app/jobs/process_imported_file_job.rb
+++ b/app/jobs/process_imported_file_job.rb
@@ -1,0 +1,20 @@
+class ProcessImportedFileJob < ActiveFedoraIdBasedJob
+  # :nocov:
+  def queue_name
+    return :ingest
+  end
+  # :nocov:
+
+  def run
+    Rails.logger.info "[INGEST] Characterizing #{generic_file.id}"
+    generic_file.characterize
+
+    Rails.logger.info "[INGEST] Creating derivatives for #{generic_file.id}"
+    generic_file.create_derivatives
+ 
+    if generic_file.image?
+      Rails.logger.info "[INGEST] Extracting EXIF metadata for #{generic_file.id}"
+      generic_file.import_exif_metadata
+    end
+  end
+end

--- a/app/jobs/reindex_collection_permissions_job.rb
+++ b/app/jobs/reindex_collection_permissions_job.rb
@@ -3,9 +3,11 @@
 # before_save method in the Collection class that triggers the resolution of
 # permissions
 class ReindexCollectionPermissionsJob 
+  # :nocov:
   def queue_name
     :permissions
   end
+  # :nocov:
 
   def run
     # Collection.find_each is marginally faster than the alternatives for

--- a/app/jobs/update_collection_members_job.rb
+++ b/app/jobs/update_collection_members_job.rb
@@ -4,9 +4,11 @@ require 'csv'
 class UpdateCollectionMembersJob < ActiveFedoraIdBasedJob
   attr_accessor :csv_source
   
+  # :nocov:
   def queue_name
     :batch_update
   end
+  # :nocov:
 
   def initialize(csv_source)
     self.csv_source = File.expand_path(csv_source)

--- a/app/jobs/update_collection_metadata_job.rb
+++ b/app/jobs/update_collection_metadata_job.rb
@@ -4,9 +4,11 @@ require 'csv'
 class UpdateCollectionMetadataJob < ActiveFedoraIdBasedJob
   attr_accessor :csv_source
   
+  # :nocov:
   def queue_name
     :batch_update
   end
+  # :nocov:
 
   def initialize(csv_source)
     self.csv_source = File.expand_path(csv_source)

--- a/app/models/concerns/cma/generic_file/characterization.rb
+++ b/app/models/concerns/cma/generic_file/characterization.rb
@@ -5,9 +5,7 @@ module CMA
   module GenericFile
     module Characterization
       def characterize
-        Rails.logger.info "[CHARACTERIZE] Processing #{self.id}"
-        # TODO: Remove hard coded arbitrary limit
-        metadata = (content.size < (200 * 2**30)) ?
+        metadata = (content.size < Sufia.config.characterization_service_limit) ?
           CMA::CharacterizationService.characterize(content) :
           content.extract_metadata
         characterization.ng_xml = metadata if metadata.present?
@@ -15,6 +13,45 @@ module CMA
         self.filename = [content.original_name]
         save
       end
+
+      def import_exif_metadata
+        return unless self.image?
+      
+        Hydra::Derivatives::TempfileService.create(content) do |f|
+          exif = MiniExiftool.new f.path
+        
+          Sufia.config.exif_to_desc_mapping.each_pair do |node, field|
+            next if exif[node].nil?
+
+            metadata = normalize(exif[node])
+            Rails.logger.info "[EXIF] Processing #{field.to_s}"
+
+            self[field] = self[field].is_a?(Array) ? 
+              metadata + self[field] : 
+              metadata.join(" ")
+          end
+        end
+
+        Sufia.config.default_metadata_fields.each_pair do |property, value|
+          self[property] += [value].flatten unless self[property].include? value
+        end
+        save
+      end
+
+      private
+        def normalize field
+          properties = [field].flatten
+
+          normalized_properties = []
+          properties.each do |prop|
+            prop = prop.to_s.gsub("|", "--")
+            prop.gsub!(/[[:cntrl:]]/, "")
+
+            normalized_properties += [prop]
+          end
+
+          normalized_properties
+        end
     end
   end
 end

--- a/app/models/concerns/cma/generic_file/derivatives.rb
+++ b/app/models/concerns/cma/generic_file/derivatives.rb
@@ -11,12 +11,12 @@ module CMA
     		obj.transform_file :content, { 
               access: { 
                 format: 'jpg',    						
-                size: '1200x1000>',
+                size: '@1200000',
     		    datastream: 'access'
     		  },
               thumbnail: { 
                 format: 'jpg',                
-                size: '200x150>',
+                size: '@30000',
                 datastream: 'thumbnail'
               },
     		}, processor: :exif_image

--- a/app/models/fixity.rb
+++ b/app/models/fixity.rb
@@ -1,48 +1,29 @@
-require 'pry'
-
 class Fixity
+  attr_accessor :file, :local, :remote
+
   def initialize(id)
-    solr_resource = GenericFile.load_instance_from_solr(id)
-    
-    @remote_digest = {uri: "#{solr_resource.uri}/content/fcr:fixity"}
-    @local_digest = {path: solr_resource.import_url.sub("file://", "")}
+    @file = GenericFile.load_instance_from_solr(id)
+    @local_digest = nil
+    @remote_digest = nil
   end
 
   def remote
-    if @remote_digest[:checksum].nil?
-      begin
-        RDF::Reader.open(@remote_digest[:uri]) do |reader|
-          reader.each_statement do |triple|
-            if triple.predicate.eql? RDF::Vocab::PREMIS.hasMessageDigest
-              digest = triple.object.value
-              scheme, algorithm, checksum = digest.split(":")
-
-              @remote_digest[:algorithm] = algorithm
-              @remote_digest[:checksum] = checksum
-            end
-          end
-        end
-      rescue IOError => error
-        puts "ERROR: Could not retrieve fixity data from Fedora"
-        puts error
-        @remote_digest[:checksum] = false
-        @remote_digest[:algorithm] = nil
-      end
+    begin
+      @remote_digest ||= CMA::FixityService.new(@file.id).fixity.first
+    rescue Ldp::NotFound
+      Rails.logger.warn "[FIXITY] Could not resolve fixity for #{@file.id}"
+      @remote_digest = false
     end
-
-    @remote_digest
   end
 
   def local
-    @local_digest[:algorithm] ||= 'sha1'
-    
-    if @local_digest[:checksum].nil?
-      if File.exists? @local_digest[:path]
-        @local_digest[:checksum] = Digest::SHA1.file(@local_digest[:path]).hexdigest
+    if @local_digest.nil?
+      path = @file.import_url.sub("file://", "")
+      if File.exists? path
+        @local_digest = Digest::SHA1.file(path).hexdigest
       else
-        # If the file does not exist set checksum to false since you cannot
-        # calculate the SHA1 for a file that is not present
-        @local_digest[:checksum] = false
+        Rails.logger.warn "[FIXITY] Cannot calculate SHA1 digest for file at #{path}"
+        @local_digest = false
       end
     end
 
@@ -50,11 +31,6 @@ class Fixity
   end
 
   def equal?
-    (local[:algorithm] == remote[:algorithm]) &&
-    (local[:checksum] == remote[:checksum])
-  end
-
-  def updated?
-    !self.equal?
+    @local_digest != false && (@local_digest == @remote_digest)
   end
 end

--- a/app/services/cma/fixity_service.rb
+++ b/app/services/cma/fixity_service.rb
@@ -1,0 +1,24 @@
+require 'pry'
+
+module CMA
+  class FixityService < ActiveFedora::FixityService
+    attr_accessor :file
+
+    def initialize id
+      @file = ::GenericFile.load_instance_from_solr id
+      @target = @file.uri + "/content"
+    end
+
+    def fixity
+      @response = fixity_response_from_fedora if @response.nil?
+      urns = fixity_graph.query(predicate: premis_digest_predicate).map(&:object)
+      urns.map! { |urn| urn.value.split(":").last }
+    end
+
+    private
+      def premis_digest_predicate
+        ::RDF::Vocab::PREMIS.hasMessageDigest
+      end
+   
+  end
+end

--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -8,29 +8,35 @@ Sufia.config do |config|
 
   # Exif to Dublin Core mappings
   config.exif_to_desc_mapping = {
-    subject: :subject,
-    hierarchicalSubject: :subject,
-    personInImage: :subject,
-    keywords: :subject,
+    Subject: :subject,
+    HierarchicalSubject: :subject,
+    PersonInImage: :subject,
+    Keywords: :subject,
     SourceFile: :source,
-    sourcefile: :source,
     JobID: :identifier,
-    headline: :abstract,
-    description: :description,
-    sublocation: :spatial,
-    location: :spatial,
+    Headline: :abstract,
+    Description: :description,
+    Sublocation: :spatial,
+    Location: :spatial,
     DateTimeOriginal: :date_created,
     CreateDate: :date_created,
-    datetimecreated: :date_created,
+    DateTimeCreated: :date_created,
     DateTime: :date_modified,
     ModifyDate: :date_modified,
-    datetimemodifed: :date_modified,
+    DateTimeModifed: :date_modified,
     # These are CMA specific fields
     'by-linetitle' => :photographer_title,
     AuthorsPosition: :photographer_title,
     'by-line' => :photographer,
-    creator: :photographer,
-    credit: :credit_line
+    Creator: :photographer,
+    Credit: :credit_line
+  }
+  # Default fields for images
+  config.default_metadata_fields = {
+    rights: "Copyright, The Cleveland Museum of Art",
+    contributor: "Cleveland Museum of Art",
+    language: "en",
+    resource_type: "Image"
   }
 
   config.max_days_between_audits = 7
@@ -103,6 +109,10 @@ Sufia.config do |config|
 
   # Specify how many seconds back from the current time that we should show by default of the user's activity on the user's dashboard
   config.activity_to_show_default_seconds_since_now = 24*60*60
+
+  # Cutoff for using web based characterization versus the command line
+  # Tailor for performance and load
+  config.characterization_service_limit = 500*(2**20)
 
   # Specify a date you wish to start collecting Google Analytic statistics for.
   # Leaving it blank will set the start date to when ever the file was uploaded by

--- a/config/initializers/sufia_events.rb
+++ b/config/initializers/sufia_events.rb
@@ -1,3 +1,3 @@
 Sufia.config.after_create_content = lambda { |generic_file, user|
-  Sufia.queue.push(ExtractExifMetadataJob.new(generic_file.id))
+  #Sufia.queue.push(ExtractExifMetadataJob.new(generic_file.id))
 }

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -86,5 +86,17 @@ RSpec.describe Collection, type: :model do
       expect(collection.has_images?).to be false
     end
   end
+
+  describe "#featured?" do
+    let(:collection) { FactoryGirl.create :collection }
+    let(:featured_collection) { FactoryGirl.create :collection }
+
+    it "reports featured status" do
+      FeaturedCollection.create(collection_id: featured_collection.id)
+    
+      expect(featured_collection.featured?).to be true
+      expect(collection.featured?).to be false
+    end
+  end
 end
 

--- a/spec/models/fixity_spec.rb
+++ b/spec/models/fixity_spec.rb
@@ -17,18 +17,21 @@ RSpec.describe Fixity do
     end
 
     it "should have a valid checksum" do
-     expect(fixity.remote[:checksum]).to eq "f4bdeae4040d68a3977dee8d9a31a0137e741c44"
-    end
-    
-    it "should encode checksum in SHA1" do
-       expect(fixity.remote[:algorithm]).to eq "sha1"
-    end
-
-    it "should validate against Fedora's fixity service" do
-      expect(fixity.remote[:uri]).to end_with("/content/fcr:fixity")
+     expect(fixity.remote).to eq "f4bdeae4040d68a3977dee8d9a31a0137e741c44"
     end
   end
 
   describe "#local" do
+    it "should be able to recover from bad file paths" do
+      file = FactoryGirl.create(:generic_file, 
+        import_url: "file://dev/null/badFilePath.png")
+      fixity = Fixity.new file.id
+      expect(fixity.local).to eq false
+    end
+
+    it "should use SHA1 checksums" do
+      fixity = Fixity.new generic_file.id
+      expect(fixity.local).to eq "d5dec89bed8b8ca7555ba7c947809bf28720b08c"
+    end
   end
 end


### PR DESCRIPTION
Rather than calling three tasks treat each ingest as an atomic action. By doing this the time to process a file is reduced by roughly 25% with less calls to Solr, Fedora, and other parts of the stack. The old jobs are retained in case you need to do something individually.

Test coverage has also been bumped up a little bit.