### PR TITLE
Send notification when batch ingest begins

### DIFF
--- a/app/mailers/batch_mailer.rb
+++ b/app/mailers/batch_mailer.rb
@@ -1,0 +1,15 @@
+class BatchMailer < ActionMailer::Base
+  default from: 'batches@archives.clevelandart.org'
+   
+  def batch_started_email users, batch, directories
+    @users = users
+    @batch = batch
+    @directories = directories
+
+    recipients = @users.map { |u| u.email }
+    mail(
+      to: recipients, 
+      subject: "Archival repository batch initiated for #{@batch.title.first}"
+    ) 
+  end
+end

--- a/app/views/batch_mailer/batch_started_email.text.erb
+++ b/app/views/batch_mailer/batch_started_email.text.erb
@@ -1,0 +1,7 @@
+<%= @batch.title.first %> has been started at <%= @batch.create_date %>. Check <%= catalog_index_url(q: @batch.id, search_field: "batch") %> regularly for status updates.
+
+Directories
+===========
+<% @directories.each do |path| %>
+* <%= path %>
+<% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,5 +51,8 @@ Rails.application.configure do
   # Suppress whiny output from the web console
   config.web_console.whiny_requests = false
   config.web_console.whitelisted_ips = "192.168.56.1"
+
+  # Default host should be local
+  config.action_mailer.default_url_options = { host: "192.168.56.102", port: 82 }
 end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,4 +83,7 @@ Rails.application.configure do
   ActiveSupport::Deprecation.silenced = true
   Deprecation.default_deprecation_behavior = :silence
   ActiveFedora::Base.logger.level = :warn if ActiveFedora::Base.logger
+
+  # Production host should reflect stability of environment
+  config.action_mailer.default_url_options = {host: "archive.clevelandart.org"}
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # For tests just use localhost
+  config.action_mailer.delivery_method = :test
+  config.action_mailer.default_url_options = {host: "localhost"}
 end

--- a/lib/tasks/cma/batch.rake
+++ b/lib/tasks/cma/batch.rake
@@ -12,6 +12,10 @@ namespace :cma do
               puts "Queuing #{directory} for ingest\n"
               Sufia.queue.push BatchIngestJob.new(path, batch.id)
 	  	    end
+
+            collections = csv_files.map { |path| File.split(path)[0].sub(args[:base_directory], "") }
+            recipients = User.where(login: RoleMapper.map["batch-admin"])
+            BatchMailer.batch_started_email(recipients, batch, collections).deliver_now
         end
 
         desc "Batch update metadata"

--- a/spec/mailers/batch_mailer_spec.rb
+++ b/spec/mailers/batch_mailer_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe BatchMailer do
+  let(:users) { [FactoryGirl.create(:user, email: "rspec@test.org")] }
+  let(:batch) { FactoryGirl.create :batch, title: ["RSpec Mock Test"] }
+  let(:directories) { ["/dev/null", "/opt/test", "/mnt/rspec"] }
+
+  before(:each) do 
+    ActionMailer::Base.deliveries = []
+  end
+
+  it "notifies when a new batch ingest begins" do
+    BatchMailer.batch_started_email(users, batch, directories).deliver_now
+
+    deliveries = ActionMailer::Base.deliveries
+    expect(deliveries.count).to eq 1
+    expect(deliveries.first.from).to eq ["batches@archives.clevelandart.org"]
+    expect(deliveries.first.to).to eq ["rspec@test.org"]
+    expect(deliveries.first.subject).to include "RSpec Mock Test"
+  end
+
+  subject(:email) { BatchMailer.batch_started_email(users, batch, directories).deliver_now }
+  it "includes a listing of processed directories" do
+    expect(email.body.encoded).to include "RSpec Mock Test"
+    expect(email.body.encoded).to include "/dev/null"
+    expect(email.body.encoded).to include "/opt/test"
+    expect(email.body.encoded).to include "/mnt/rspec"
+  end
+end


### PR DESCRIPTION
When manually kicking off a batch ingest with Rake send an email to members of the batch-admin group so they can monitor the progress. This is part of a long term plan to kick off notifications when an entire batch is complete and ready for review.