### PR TITLE
Respond to typical permissions errors gracefully

### DIFF
--- a/app/services/ingest_file_into_local_repository_service.rb
+++ b/app/services/ingest_file_into_local_repository_service.rb
@@ -5,20 +5,23 @@ class IngestFileIntoLocalRepositoryService
       raise FileIngestError.new "Cannot ingest into repository from itself" 
     end  
 
-    # TODO: Wrap this neatly in a begin / rescue block to catch 
-    #       - Out of disk space
-    #       - Permission denied
-    #
     # TODO: Use generic_file.local_file instead of repeating code?
     pair = generic_file.id.scan(/..?/).first(4)
     destination = File.join(CMA.config["repository"]["root"], *pair, generic_file.id)
-    FileUtils.mkdir_p File.dirname(destination)
- 
-    FileUtils.cp source, destination
-    FileUtils.chmod 0640, destination
-    FileUtils.chown CMA.config["repository"]["owner"],
-      CMA.config["repository"]["group"],
-      destination
+    begin
+      FileUtils.mkdir_p File.dirname(destination)
+      FileUtils.cp source, destination
+      FileUtils.chmod 0640, destination
+      FileUtils.chown CMA.config["repository"]["owner"],
+        CMA.config["repository"]["group"],
+        destination
+    rescue Errno::EPERM
+      # Not fatal but worth noting
+      Rails.logger.warn "[INGEST FILE] Unable to set ownership for #{destination}"
+    rescue Errno::EACCES
+      Rails.logger.warn "[INGEST FILE] Could not copy file to repository (#{destination})"
+      raise FileIngestError.new "Permission denied trying to copy #{source} to #{destination}"
+    end
 
     checksum = Digest::SHA1.file(destination).hexdigest
     Rails.logger.info "[INGEST FILE] Writing out SHA1 checksum for #{generic_file.id} to #{destination}.sha1"


### PR DESCRIPTION
Expand code base to handle two common errors

1) Inability to update permissions - not fatal but a very severe condition which needs to be recorded for later troubleshooting
2) Permission denied to copy the file - needs to raise an error that halts ingest immediately