### PR TITLE
Calculate file sizes for external files

### DIFF
--- a/app/models/concerns/cma/generic_file/metadata.rb
+++ b/app/models/concerns/cma/generic_file/metadata.rb
@@ -49,7 +49,12 @@ module CMA
         property :device, predicate: ::RDF::URI.new("http://library.clevelandart.org/ns/#capture_device") do |index|
           index.as :stored_searchable
         end
-     end
+
+        # TODO: Give this field a better RDF mapping
+        property :stored_mime_type, predicate: ::RDF::URI.new("http://library.clevelandart.org/ns/#mime_type") do |index|
+          index.as :stored_searchable
+        end
+      end
     end
   end
 end

--- a/app/models/concerns/cma/solr_document_behavior.rb
+++ b/app/models/concerns/cma/solr_document_behavior.rb
@@ -2,20 +2,12 @@ module CMA
   module SolrDocumentBehavior
     def source
       source_field = Solrizer.solr_name('source', :stored_searchable)
-      if has? source_field
-        fetch(source_field).first
-      else
-        nil
-      end
+      has?(source_field) ? fetch(source_field).first : nil
     end
 
     def subject
       subject_field = Solrizer.solr_name('subject', :stored_searchable)
-      if has? subject_field
-        fetch(subject_field)
-      else
-        []
-      end
+      has?(subject_field) ? fetch(subject_field) : []
     end
 
     def members

--- a/app/models/datastreams/cma_file_content_datastream.rb
+++ b/app/models/datastreams/cma_file_content_datastream.rb
@@ -6,9 +6,15 @@ class CMAFileContentDatastream < FileContentDatastream
   def container
     @container ||= GenericFile.load_instance_from_solr id.split("/").first
   end
-    
+  
   def stream(range = nil)
+    return nil if new_record?
     local_file? ? LocalFileBody.new(container.local_file) : super
+  end
+
+  def size
+    return 0 if new_record?
+    local_file? ? File.size(container.local_file) : super
   end
 
   private
@@ -20,4 +26,3 @@ class CMAFileContentDatastream < FileContentDatastream
       File.exists? container.local_file
     end
 end
-

--- a/app/models/datastreams/concerns/cma/external_file.rb
+++ b/app/models/datastreams/concerns/cma/external_file.rb
@@ -1,0 +1,18 @@
+module CMA
+  module Datastreams
+    module ExternalFile
+      def stream(range = nil)
+        LocalFileBody.new(container.local_file)
+      end
+
+      def size
+        File.size(container.local_file)
+      end
+  
+      private 
+        def retrieve_content
+          File.binread(container.local_file)
+        end
+    end
+  end
+end

--- a/app/models/generic_file.rb
+++ b/app/models/generic_file.rb
@@ -6,8 +6,6 @@ class GenericFile < ActiveFedora::Base
     include Sufia::GenericFile::Export
     include Sufia::GenericFile::Characterization
     include Sufia::GenericFile::Permissions
-    #include Sufia::GenericFile::Trophies
-    #include Sufia::GenericFile::Featured
     include Sufia::GenericFile::Versions
     include Sufia::GenericFile::ProxyDeposit
     include Hydra::Collections::Collectible

--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -3,7 +3,8 @@ Sufia.config do |config|
 
   config.fits_to_desc_mapping= {
     file_title: :title,
-    file_author: :creator
+    file_author: :creator,
+    stored_mime_type: :mime_type
   }
 
   # Exif to Dublin Core mappings

--- a/spec/factories/generic_files.rb
+++ b/spec/factories/generic_files.rb
@@ -16,7 +16,7 @@ FactoryGirl.define do
     end
 
     trait :with_content do
-      before(:create) do |file|
+      after(:create) do |file|
         file.add_file(File.new(File::NULL), {path: 'content',
           original_name: "lagoon.jpg",
           mime_type: "image/jpg"})

--- a/spec/jobs/batch_ingest_job_spec.rb
+++ b/spec/jobs/batch_ingest_job_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe BatchIngestJob do
       expect { job.run }.to raise_error(CMA::Exceptions::FileNotFoundError)
     end
 
+    it "raises an exception if batches do not exist" do
+      job = BatchIngestJob.new nil
+      expect(job.find_batch "bad-id").to be_nil
+    end
+
     it "creates a new collection" do
       allow(ImportUrlJob).to receive(:new)
       allow(Sufia.queue).to receive(:push)

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe ImportUrlJob do
 
     it "should ingest the bitstream(s) into Fedora" do
       expect(job.queue_name).to eq :import
-      expect(generic_file.content.has_content?).to be nil
-      expect(generic_file.content.size).to be_nil
+      expect(generic_file.content.has_content?).to be false
+      expect(generic_file.content.size).to eq 0
 
       job.run
       generic_file.reload

--- a/spec/jobs/ingest_local_file_job_spec.rb
+++ b/spec/jobs/ingest_local_file_job_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe IngestLocalFileJob do
       expect(File.exists? resource_path).to eq true
       expect(file.content.mime_type).to eq "message/external_body; access-type=URL; url=\"http://localhost:3000/downloads/#{file.id}\""
       expect(file.content.original_name).to eq "lagoon.tif"
-      expect(file.content.size).to eq 0
+      expect(file.content.size).to eq 109216
 
       expect(file.mime_type).to eq "image/tiff"
       expect(file.label).to eq "lagoon.tif"

--- a/spec/services/characterization_service_spec.rb
+++ b/spec/services/characterization_service_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+require 'webmock/rspec'
+
+WebMock.allow_net_connect!
+
+RSpec.describe CMA::CharacterizationService do
+  let(:file) { FactoryGirl.create(:generic_image_with_content,
+    import_url: "file://#{Rails.root}/spec/fixtures/lagoon.jpg") }
+  
+  describe "#characterize" do
+    it "gracefully recovers from timeout errors" do
+      pending "To be implemented later"
+      stub_request(:any, /\/fits/).to_timeout
+      allow(Sufia.queue).to receive(:push)
+      IngestLocalFileJob.new(file.id).run
+
+      expect { CMA::CharacterizationService.characterize(file.content) }.to raise_error(Net::ReadTimeout) 
+    end
+
+    it "recovers from non 200 response codes" do
+      stub_request(:any, /\/fits/).
+        to_return(status: [500, "Service Unavailable"])
+      allow(Sufia.queue).to receive(:push)
+      IngestLocalFileJob.new(file.id).run
+
+      expect { CMA::CharacterizationService.characterize(file.content) }.to raise_error(CMA::UnexpectedServerResponse)
+    end
+  end
+end


### PR DESCRIPTION
* Restore file size reporting for externally hosted files
   When files are locally hosted the reported size is 0. This means that characterization does not run nor can you get accurate values through the interface. This fixes the issue with a small patch to the FileContentDatastream class.

* Bump up test coverage to ~94%
   Add coverage for a couple of classes. Coupled with some minor refactoring this leaves less than 50 lines to reach 100%. Most of the remaining tests need to be written against views using Cucumber to describe workflows ("When I search for ...", "When I download ...", etc)