### PR TITLE
Warn if no administrators are set for batch monitoring

### DIFF
--- a/app/mailers/batch_mailer.rb
+++ b/app/mailers/batch_mailer.rb
@@ -1,5 +1,5 @@
 class BatchMailer < ActionMailer::Base
-  default from: 'batches@archives.clevelandart.org'
+  default from: 'cmaarchives.notifications@clevelandart.org'
    
   def batch_started_email users, batch, directories
     @users = users

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -83,4 +83,8 @@ Rails.application.configure do
   ActiveSupport::Deprecation.silenced = true
   Deprecation.default_deprecation_behavior = :silence
   ActiveFedora::Base.logger.level = :warn if ActiveFedora::Base.logger
+
+  # Default hosts for services
+  config.default_url_options = { host: "appdev01.clevelandart.org" }
+  config.action_mailer.default_url_options = config.default_url_options
 end

--- a/lib/tasks/cma/batch.rake
+++ b/lib/tasks/cma/batch.rake
@@ -15,7 +15,12 @@ namespace :cma do
 
             collections = csv_files.map { |path| File.split(path)[0].sub(args[:base_directory], "") }
             recipients = User.where(login: RoleMapper.map["batch-admin"])
-            BatchMailer.batch_started_email(recipients, batch, collections).deliver_now
+   
+            if recipients.empty?
+              puts "WARNING: No recipients specified for ingest notifications. Check the batch-admin group in config/role_map.yml"
+            else
+              BatchMailer.batch_started_email(recipients, batch, collections).deliver_now
+            end
         end
 
         desc "Batch update metadata"


### PR DESCRIPTION
In situations where no batch-admin group is defined the tasks should emit a warning instead of failing silently. This should uses a stock @clevelandart.org email address which should work much better with SMTP and ActionMailer than the custom domain that was previously defined.