### PR TITLE
Reorganize breadcrumb logic

### DIFF
--- a/app/controllers/concerns/cma/breadcrumbs.rb
+++ b/app/controllers/concerns/cma/breadcrumbs.rb
@@ -21,31 +21,42 @@ module CMA
     end
 
     def trail_from_referer
-        add_breadcrumb I18n.t("sufia.bread_crumb.search_results"), request.referer
-        add_breadcrumb_for_resource params[:id]
-    end
-
-    def add_breadcrumb_for_resource resource_id
-      item = ActiveFedora::Base.load_instance_from_solr(resource_id)
-
+      add_breadcrumb I18n.t("sufia.bread_crumb.search_results"), request.referer
+      item = ActiveFedora::Base.load_instance_from_solr params[:id]
       case item.class.to_s
         when "GenericFile"
-          add_breadcrumb item.title.first, sufia.generic_file_path(item.id)
+          add_breadcrumb_for_resource params[:id], item.title.first
         when "Collection"
-          add_breadcrumb item.title, collections.collection_path(item.id)
+          add_breadcrumb_for_collection params[:id], item.title
       end
+    end
+
+    def add_breadcrumb_for_resource id, label
+      add_breadcrumb label, sufia.generic_file_path(id)
+    end
+
+    def add_breadcrumb_for_collection id, label
+      add_breadcrumb label, collections.collection_path(id)
+    end
+
+    def add_breadcrumb_for_administrative_collection id, label
+      facet = ActiveFedora::SolrQueryBuilder.solr_name(:administrative_collection, :facetable)
+      add_breadcrumb label, catalog_index_path("f[#{facet}][]": label)
     end
 
     def add_breadcrumb_trail_for_resource id
       item = ActiveFedora::Base.load_instance_from_solr(id)
-      breadcrumb_ids = [item.id]
-  
-      while item.collection_ids.present?
-        breadcrumb_ids.unshift item.collection_ids.first
-        item = ActiveFedora::Base.load_instance_from_solr(item.collection_ids.first)
+ 
+      add_breadcrumb_for_administrative_collection item.administrative_collection.id, item.administrative_collection.title
+      # Because routes are in different engines we can't just use url_for
+      # in this situation
+      if "Collection" == item.class.to_s
+        add_breadcrumb_for_collection item.id, item.title
+      elsif "GenericFile" == item.class.to_s
+        coll = ::Collection.load_instance_from_solr item.collection_ids.first
+        add_breadcrumb_for_collection coll.id, coll.title
+        add_breadcrumb_for_resource item.id, item.title.first
       end
-    
-      breadcrumb_ids.each { |b_id| add_breadcrumb_for_resource(b_id) } 
     end
   end
 end

--- a/app/presenters/cma/generic_file_presenter.rb
+++ b/app/presenters/cma/generic_file_presenter.rb
@@ -40,7 +40,11 @@ module CMA
     end
 
     def title
-      return model.title
+      if model.title.is_a? Array
+        model.title.first
+      else
+        model.title
+      end
     end
 
     def member_presenters

--- a/app/views/generic_files/_show_collections.html.erb
+++ b/app/views/generic_files/_show_collections.html.erb
@@ -12,5 +12,7 @@
             <%= link_to c.title, collections.collection_path(c) %>
           <% end %>
         <% end %>
+
+        <%= link_to @generic_file.administrative_collection.title, catalog_index_path(collection_params_for_catalog(@generic_file.administrative_collection.title)) if @generic_file.administrative_collection.present? %>
       </ul>
     <% end %>


### PR DESCRIPTION
Because the new model no longer contains nested collections the breadcrumb navigation needs to be adjusted accordingly. Instead of 

Collection / Collection / File

it now displays

Administrative Collection / Collection / File

where Administrative Collection is a canned search 