### PR TITLE
Externalize FITS service uri in configuration

### DIFF
--- a/app/services/cma/characterization_service.rb
+++ b/app/services/cma/characterization_service.rb
@@ -1,10 +1,6 @@
 module CMA
   class CharacterizationService
     def self.characterize content
-      # TODO: Make these configurable
-      uri = "http://127.0.0.1:8888/fits/examine"
-      timeout = 180
-
       # No point continuing if there is nothing to process
       return unless content.has_content?
 
@@ -15,9 +11,11 @@ module CMA
         f.chmod(0644)
 
         begin
-          response = HTTParty.get(uri, query: {file: f.path}, timeout: timeout)
+          response = HTTParty.get(CMA.config["fits"]["uri"], 
+            query: {file: f.path}, 
+            timeout: CMA.config["fits"]["timeout"])
         rescue Net::ReadTimeout => timeout_error
-          Rails.logger.warn "[CHARACTERIZE] Could not connect to #{uri}?file=#{f.path} after waiting #{timeout} seconds"
+          Rails.logger.warn "[CHARACTERIZE] Could not connect to #{CMA.config["fits"]["uri"]}?file=#{f.path} after waiting #{CMA.config["fits"]["timeout"]} seconds"
             raise timeout_error
         end
 
@@ -25,10 +23,10 @@ module CMA
           # Kludge because the information that comes back from FITS Servlet is not
           # actually indicated to be UTF-8. Need to open an issue with the upstream
           # repository after which this code can be simplified
-          Rails.logger.info "[CHARACTERIZE] Characterization complete for #{uri}?file=#{f.path}"
+          Rails.logger.info "[CHARACTERIZE] Characterization complete for #{CMA.config["fits"]["uri"]}?file=#{f.path}"
           return response.body.force_encoding("iso-8859-1").encode("utf-8")
         else
-          raise UnexpectedServerResponse.new("Received HTTP status code #{response.code} from #{uri}")
+          raise UnexpectedServerResponse.new("Received HTTP status code #{response.code} from #{CMA.config["fits"]["uri"]}")
         end
       end
     end

--- a/spec/services/characterization_service_spec.rb
+++ b/spec/services/characterization_service_spec.rb
@@ -8,9 +8,16 @@ RSpec.describe CMA::CharacterizationService do
     import_url: "file://#{Rails.root}/spec/fixtures/lagoon.jpg") }
   
   describe "#characterize" do
+    before(:each) do
+      @default_timeout = CMA.config["fits"]["timeout"]
+    end
+   
+    after(:each) do
+      CMA.config["fits"]["timeout"] = @default_timeout
+    end
+
     it "gracefully recovers from timeout errors" do
-      pending "To be implemented later"
-      stub_request(:any, /\/fits/).to_timeout
+      CMA.config["fits"]["timeout"] = 0
       allow(Sufia.queue).to receive(:push)
       IngestLocalFileJob.new(file.id).run
 


### PR DESCRIPTION
Do not hard code configuration variables in the code where possible. This opens up the possibility of running the application on a secondary machine to speed up ingest.

**Deployments will need to be updated to include** 

fits:
  uri: http://example.com/fits
  timeout: time_in_seconds