### PR TITLE
Allow content migrations to run in the background

### DIFF
--- a/app/jobs/migrate_collection_to_external_storage_job.rb
+++ b/app/jobs/migrate_collection_to_external_storage_job.rb
@@ -1,0 +1,64 @@
+# Deletes old versions of the resource and copies them from internal
+# Fedora storage to an external location. If all objects already exist in
+# the external storage no action is taken
+class MigrateCollectionToExternalStorageJob 
+  attr :collection
+
+  def initialize collection_id
+    @collection ||= Collection.load_instance_from_solr collection_id
+  end
+
+  def queue_name
+    :migrate
+  end
+
+  def run
+    collection.members.each_with_index do |gf|
+      next if File.exists? gf.local_file
+
+      import_path = File.expand_path gf.import_url.gsub("file://", "")
+      if File.exists? import_path
+        migrate_content gf
+      else
+        create_temporary_file gf
+      end
+    end
+  end
+
+  def create_temporary_file generic_file
+    original_path = generic_file.import_url.gsub("file://", "")
+    if File.exists? original_path
+      logger.warn "[MIGRATE #{generic_file.id}] File already exists at #{original_path}"
+    else 
+      Hydra::Derivatives::TempfileService.create(generic_file.content) do |tmp_file|
+        logger.info "[MIGRATE #{generic_file.id}] Writing temporary file to #{tmp_file.path}"
+        begin 
+          generic_file.import_url = "file://#{tmp_file.path}"
+          generic_file.save
+
+          migrate_content generic_file
+        ensure
+          generic_file.import_url = "file://#{original_path}"
+          generic_file.save
+        end
+      end
+    end
+
+    return original_path
+  end
+
+  def migrate_content gf
+    if gf.content.versions.all.count > 0
+      logger.info "[MIGRATE #{gf.id}] Removing expired versions"
+      gf.content.delete(eradicate: true)
+    end
+      
+    logger.info "[MIGRATE #{gf.id}] Moving content to external storage"
+    IngestLocalFileJob.new(gf.id).run
+  end
+
+  # WIP
+  def logger
+    Rails.logger
+  end
+end

--- a/spec/jobs/migrate_collection_to_external_storage_job_spec.rb
+++ b/spec/jobs/migrate_collection_to_external_storage_job_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe MigrateCollectionToExternalStorageJob do
+  describe "#run" do
+    let(:file) { FactoryGirl.create(:generic_image_with_content,
+      import_url: "file://#{File.expand_path("spec/fixtures/lagoon.jpg")}") }
+    let(:collection) { FactoryGirl.create(:collection, members: [file]) }
+
+    it "leaves existing external content in place" do
+      IngestLocalFileJob.new(file.id).run
+
+      expect(File.exists?(file.local_file)).to be true
+      expect(file.content.size).to eq 9610
+      expect(Digest::SHA1.file(file.local_file).hexdigest).to eq "c98a7d2549289abcb7813e3e973ceb797511dfe1"
+   
+      MigrateCollectionToExternalStorageJob.new(collection.id).run
+
+      expect(File.exists? file.local_file).to be true
+      expect(file.content.size).to eq 9610
+      expect(Digest::SHA1.file(file.local_file).hexdigest).to eq "c98a7d2549289abcb7813e3e973ceb797511dfe1"
+    end
+
+    it "migrates bitstreams from Fedora" do
+      ImportUrlJob.new(file.id).run
+
+      expect(File.exists?(file.local_file)).to be false
+      expect(file.content.size).to be 9610
+
+      MigrateCollectionToExternalStorageJob.new(collection.id).run
+
+      expect(File.exists? file.local_file).to be true
+      expect(File.size file.local_file).to be 9610
+    end
+  
+    it "works with files no longer on disk" do
+      ImportUrlJob.new(file.id).run
+      file.import_url = "file://path-to-null-file"
+      file.save
+
+      expect(File.exists? file.import_url.gsub("file://", "")).to be false
+
+      MigrateCollectionToExternalStorageJob.new(collection.id).run
+  
+      expect(File.exists? file.local_file).to be true
+      expect(File.size file.local_file).to be 9610
+      expect(Digest::SHA1.file(file.local_file).hexdigest).to eq "c98a7d2549289abcb7813e3e973ceb797511dfe1" 
+      expect(file.import_url).to eq "file://path-to-null-file"
+    end
+  end
+end


### PR DESCRIPTION
Adds a tool for migrating collections from internal Fedora storage to externally managed datastreams. For now it can be run in a one off fashion from the command line. If required it could also potentially be supplemented with a rake task.

Once all content is migrated this code can be deprecated.