### PR TITLE
Use Sufia::Engine to resolve download URL

### DIFF
--- a/app/jobs/ingest_local_file_job.rb
+++ b/app/jobs/ingest_local_file_job.rb
@@ -20,18 +20,11 @@ class IngestLocalFileJob < ActiveFedoraIdBasedJob
     generic_file.title += [generic_file.label] if generic_file.title.empty?
     generic_file.save
 
-    # TODO: Copy file into local repository using a configurable module instead
-    #       of a hard coded one
     IngestFileIntoLocalRepositoryService.ingest(generic_file)
     Sufia.queue.push(ProcessImportedFileJob.new(generic_file.id)) 
   end
 
   def local_file_url resource
-    download_url(generic_file)
-  end
-
-  def download_url resource
-    # TODO: Make this configurable in a YAML file and using a service
-    LocalFileUrlService.new.download_url(generic_file)
+    LocalFileUrlService.download_url resource
   end
 end

--- a/app/models/datastreams/cma/external_checksum.rb
+++ b/app/models/datastreams/cma/external_checksum.rb
@@ -1,0 +1,13 @@
+module CMA
+  class ExternalChecksum
+    attr_reader :uri, :value, :algorithm
+
+    def initialize file
+      return unless File.exists? file.container.local_file
+
+      @value = Digest::SHA1.file("#{file.container.local_file}").hexdigest
+      @algorithm = 'sha1'
+      @uri = "urn:#{@algorithm}:#{@value}"
+    end
+  end
+end

--- a/app/models/datastreams/cma_file_content_datastream.rb
+++ b/app/models/datastreams/cma_file_content_datastream.rb
@@ -19,8 +19,7 @@ class CMAFileContentDatastream < FileContentDatastream
 
   def checksum
     @checksum ||= local_file? ?
-      Digest::SHA1.file(container.local_file).hexdigest :
-      super
+      CMA::ExternalChecksum.new(self) : super
   end
 
   private

--- a/app/services/local_file_url_service.rb
+++ b/app/services/local_file_url_service.rb
@@ -1,7 +1,6 @@
-class LocalFileUrlService
-  include Rails.application.routes.mounted_helpers
-  
-  def download_url generic_file
-    sufia.download_url generic_file, Rails.application.config.default_url_options
+module LocalFileUrlService
+  def self.download_url generic_file
+    Sufia::Engine.routes.url_helpers.download_url generic_file, 
+      Rails.application.config.default_url_options
   end
 end

--- a/spec/jobs/ingest_local_file_job_spec.rb
+++ b/spec/jobs/ingest_local_file_job_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe IngestLocalFileJob do
       allow(Sufia.queue).to receive(:push)
       expect(File.exists? resource_path).to eq false
    
+
       IngestLocalFileJob.new(file.id).run
       file.reload
 

--- a/spec/models/external_checksum_spec.rb
+++ b/spec/models/external_checksum_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe CMA::ExternalChecksum do
+  let!(:file) { FactoryGirl.create(:generic_image_with_content) }
+
+  after(:each) do
+    File.delete(file.local_file) if File.exists? file.local_file
+  end
+
+  describe "Valid checksum" do
+    it "has generates valid RDF" do
+      allow(Sufia.queue).to receive(:push)
+      IngestLocalFileJob.new(file.id).run
+
+      checksum = CMA::ExternalChecksum.new(file.content)
+      
+      expect(checksum.uri).to eq "urn:sha1:c98a7d2549289abcb7813e3e973ceb797511dfe1"
+      expect(checksum.algorithm).to eq "sha1"
+      expect(checksum.value).to eq "c98a7d2549289abcb7813e3e973ceb797511dfe1"
+    end
+
+    it "handles missing files" do
+      checksum = CMA::ExternalChecksum.new(file.content)
+ 
+      expect(checksum.uri).to be_nil 
+      expect(checksum.algorithm).to be_nil
+      expect(checksum.value).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Attempts to fix https://github.com/ClevelandArtGIT/cma-archives/issues/84 by using Sufia::Engine directly. The patch isn't fully effective but it does streamline future troubleshooting when this bug is revisited. As it only seems to pop up during unit testing it may not have an impact on any deployments.